### PR TITLE
Fix --no-restore for apps with arguments

### DIFF
--- a/DotNetCliPerf/CoreApp.cs
+++ b/DotNetCliPerf/CoreApp.cs
@@ -47,11 +47,12 @@ namespace DotNetCliPerf
             DotNet("build", restore: first || Restore);
         }
 
-        protected string DotNet(string arguments, string workingSubDirectory = "", bool restore = true, bool throwOnError = true)
+        protected string DotNet(string dotnetArguments, string appArguments = null, string workingSubDirectory = "", bool restore = true, bool throwOnError = true)
         {
+            var arguments = dotnetArguments + (restore ? "" : " --no-restore") + (appArguments == null ? "" : " -- " + appArguments);
             return Util.RunProcess(
                 "dotnet",
-                arguments + (restore ? "" : " --no-restore"),
+                arguments,
                 Path.Combine(RootTempDir, workingSubDirectory),
                 throwOnError: throwOnError,
                 environment: Environment

--- a/DotNetCliPerf/WebAppCore.cs
+++ b/DotNetCliPerf/WebAppCore.cs
@@ -19,7 +19,7 @@ namespace DotNetCliPerf
 
         protected override string Run(bool first = false)
         {
-            return DotNet("run -- --mode=singleRequest", restore: first || Restore, workingSubDirectory: "mvc", throwOnError: false);
+            return DotNet("run", appArguments: "--mode=singleRequest", restore: first || Restore, workingSubDirectory: "mvc", throwOnError: false);
         }
     }
 }


### PR DESCRIPTION
Right now the command for a 'no-restore' iteration is being built like:
```
dotnet run -- --mode=single-request --no-restore
```

The `--no-restore` is getting passed to the app, not to dotnet. This
change fixes that by separating arguments intended for dotnet from
arguments intended for the app.